### PR TITLE
Simplify thread0.cpp and xthrow.cpp. (#320)

### DIFF
--- a/stl/src/thread0.cpp
+++ b/stl/src/thread0.cpp
@@ -5,41 +5,37 @@
 
 #include <yvals.h>
 
-#include <mutex>
+#include <stdlib.h>
 #include <system_error>
-#include <thread>
 #include <xthreads.h>
-
-#if _HAS_EXCEPTIONS
-#include <exception>
-#include <string>
-
-#else // _HAS_EXCEPTIONS
-#include <cstdio>
-#endif // _HAS_EXCEPTIONS
-
-static const char* const msgs[] = { // error messages
-    "device or resource busy", "invalid argument", "no such process", "not enough memory", "operation not permitted",
-    "resource deadlock would occur", "resource unavailable try again"};
-
-static const int codes[] = { // system_error codes
-    (int) _STD errc::device_or_resource_busy, (int) _STD errc::invalid_argument, (int) _STD errc::no_such_process,
-    (int) _STD errc::not_enough_memory, (int) _STD errc::operation_not_permitted,
-    (int) _STD errc::resource_deadlock_would_occur, (int) _STD errc::resource_unavailable_try_again};
 
 _STD_BEGIN
 
-#if _HAS_EXCEPTIONS
-_CRTIMP2_PURE void __cdecl _Throw_Cpp_error(int code) { // throw error object
-    throw _STD system_error(codes[code], _STD generic_category(), msgs[code]);
-}
+static constexpr const char* msgs[] = {
+    // error messages
+    "device or resource busy",
+    "invalid argument",
+    "no such process",
+    "not enough memory",
+    "operation not permitted",
+    "resource deadlock would occur",
+    "resource unavailable try again",
+};
 
-#else // _HAS_EXCEPTIONS
-_CRTIMP2_PURE void __cdecl _Throw_Cpp_error(int code) { // report system error
-    _CSTD fputs(msgs[code], stderr);
-    _CSTD abort();
+static constexpr errc codes[] = {
+    // system_error codes
+    errc::device_or_resource_busy,
+    errc::invalid_argument,
+    errc::no_such_process,
+    errc::not_enough_memory,
+    errc::operation_not_permitted,
+    errc::resource_deadlock_would_occur,
+    errc::resource_unavailable_try_again,
+};
+
+[[noreturn]] _CRTIMP2_PURE void __cdecl _Throw_Cpp_error(int code) { // throw error object
+    _THROW(system_error(static_cast<int>(codes[code]), _STD generic_category(), msgs[code]));
 }
-#endif // _HAS_EXCEPTIONS
 
 [[noreturn]] _CRTIMP2_PURE void __cdecl _Throw_C_error(int code) { // throw error object for C error
     switch (code) { // select the exception

--- a/stl/src/xthrow.cpp
+++ b/stl/src/xthrow.cpp
@@ -3,60 +3,43 @@
 
 // exception handling support functions
 
+#include <functional>
 #include <new>
+#include <regex>
 #include <stdexcept>
 
 _STD_BEGIN
 
     [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL
-    _Xbad_alloc() { // report a bad_alloc error
+    _Xbad_alloc() {
     _THROW(bad_alloc{});
 }
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xinvalid_argument(
-    _In_z_ const char* _Message) { // report an invalid_argument error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xinvalid_argument(_In_z_ const char* const _Message) {
     _THROW(invalid_argument(_Message));
 }
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xlength_error(
-    _In_z_ const char* _Message) { // report a length_error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xlength_error(_In_z_ const char* const _Message) {
     _THROW(length_error(_Message));
 }
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xout_of_range(
-    _In_z_ const char* _Message) { // report an out_of_range error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xout_of_range(_In_z_ const char* const _Message) {
     _THROW(out_of_range(_Message));
 }
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xoverflow_error(
-    _In_z_ const char* _Message) { // report an overflow error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xoverflow_error(_In_z_ const char* const _Message) {
     _THROW(overflow_error(_Message));
 }
 
-[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xruntime_error(
-    _In_z_ const char* _Message) { // report a runtime_error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xruntime_error(_In_z_ const char* const _Message) {
     _THROW(runtime_error(_Message));
 }
-_STD_END
 
-#include <functional>
-
-_STD_BEGIN
-
-    [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL
-    _Xbad_function_call() { // report a bad_function_call error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xbad_function_call() {
     _THROW(bad_function_call{});
 }
-_STD_END
 
-#if _HAS_EXCEPTIONS
-#include <regex>
-
-_STD_BEGIN
-
-    [[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL
-    _Xregex_error(regex_constants::error_type _Code) { // report a regex_error
+[[noreturn]] _CRTIMP2_PURE void __CLRCALL_PURE_OR_CDECL _Xregex_error(const regex_constants::error_type _Code) {
     _THROW(regex_error(_Code));
 }
 _STD_END
-#endif // _HAS_EXCEPTIONS


### PR DESCRIPTION
* Simplify thread0.cpp and xthrow.cpp.

I verified with `#error` that these files are always compiled with
`_HAS_EXCEPTIONS=1`.

thread0.cpp
Include only necessary headers.

Move the lookup tables within `_STD_BEGIN` to avoid repeated `_STD`
qualification. They're `static`, so this doesn't affect bincompat.

Add trailing commas for readability.

Make `codes` a table of `errc` so we don't need to cast each value.

Mark `_Throw_Cpp_error` as `[[noreturn]]`, matching its declaration
in the header. (No bincompat effect.)

Use `_THROW` for consistency. (Even though exceptions are enabled,
we conventionally use this in `src`.)

`system_error` is a type, so we don't need to `_STD` qualify it.

`static_cast<int>` the `errc`, once.

xthrow.cpp
Coalesce headers. Coalesce `std` regions.

Remove unnecessary comments.

Mark value parameters as const.

* Add constexpr.

# Description



# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
