### PR TITLE
Reduce stack space consumption of list<T>::insert (#366)

### DIFF
--- a/stl/inc/forward_list
+++ b/stl/inc/forward_list
@@ -411,71 +411,101 @@ public:
 };
 
 template <class _Alnode>
-struct _Flist_insert_after_op {
+struct _Flist_insert_after_op2 {
     // forward_list insert-after operation which maintains exception safety
     using _Alnode_traits = allocator_traits<_Alnode>;
     using pointer        = typename _Alnode_traits::pointer;
     using value_type     = typename _Alnode_traits::value_type;
 
-    explicit _Flist_insert_after_op(_Alnode& _Al_) : _Al(_Al_), _Tail(_STD addressof(_Base)) {}
+    explicit _Flist_insert_after_op2(_Alnode& _Al_) : _Al(_Al_), _Tail() {}
 
-    _Flist_insert_after_op(const _Flist_insert_after_op&) = delete;
-    _Flist_insert_after_op& operator=(const _Flist_insert_after_op&) = delete;
+    _Flist_insert_after_op2(const _Flist_insert_after_op2&) = delete;
+    _Flist_insert_after_op2& operator=(const _Flist_insert_after_op2&) = delete;
 
     template <class... _CArgT>
-    pointer _Append_n(typename _Alnode_traits::size_type _Count, const _CArgT&... _Carg) {
-        // Append _Count copies of T, constructed from _Carg, to this insert-after operation
+    void _Append_n(typename _Alnode_traits::size_type _Count, const _CArgT&... _Carg) {
+        // Append _Count elements, constructed from _Carg
+        if (_Count <= 0) {
+            return;
+        }
+
         _Alloc_construct_ptr<_Alnode> _Newnode(_Al);
+        if (_Tail == pointer{}) {
+            _Newnode._Allocate(); // throws
+            _Alnode_traits::construct(_Al, _STD addressof(_Newnode._Ptr->_Myval), _Carg...); // throws
+            _Head = _Newnode._Ptr;
+            _Tail = _Newnode._Ptr;
+            --_Count;
+        }
+
         for (; 0 < _Count; --_Count) {
             _Newnode._Allocate(); // throws
             _Alnode_traits::construct(_Al, _STD addressof(_Newnode._Ptr->_Myval), _Carg...); // throws
-            _Construct_in_place(*_Tail, _Newnode._Ptr); // nothrow
-            _Tail = _STD addressof(_Newnode._Ptr->_Next);
+            _Construct_in_place(_Tail->_Next, _Newnode._Ptr);
+            _Tail = _Newnode._Ptr;
         }
 
-        return _Newnode._Release();
+        (void) _Newnode._Release();
     }
 
     template <class _InIt, class _Sentinel>
-    pointer _Append_range_unchecked(_InIt _First, const _Sentinel _Last) {
-        // Append the values in [_First, _Last) to this insert-after operation
-        _Alloc_construct_ptr<_Alnode> _Newnode(_Al);
-        for (; _First != _Last; ++_First) {
-            _Newnode._Allocate(); // throws
-            _Alnode_traits::construct(_Al, _STD addressof(_Newnode._Ptr->_Myval), *_First); // throws
-            _Construct_in_place(*_Tail, _Newnode._Ptr); // nothrow
-            _Tail = _STD addressof(_Newnode._Ptr->_Next);
+    void _Append_range_unchecked(_InIt _First, const _Sentinel _Last) {
+        // Append the values in [_First, _Last)
+        if (_First == _Last) { // throws
+            return;
         }
 
-        return _Newnode._Release();
+        _Alloc_construct_ptr<_Alnode> _Newnode(_Al);
+        if (_Tail == pointer{}) {
+            _Newnode._Allocate(); // throws
+            _Alnode_traits::construct(_Al, _STD addressof(_Newnode._Ptr->_Myval), *_First); // throws
+            const auto _Newhead = _Newnode._Release();
+            _Head               = _Newhead;
+            _Tail               = _Newhead;
+            ++_First; // throws
+        }
+
+        while (_First != _Last) { // throws
+            _Newnode._Allocate(); // throws
+            _Alnode_traits::construct(_Al, _STD addressof(_Newnode._Ptr->_Myval), *_First); // throws
+            const auto _Newtail = _Newnode._Release();
+            _Construct_in_place(_Tail->_Next, _Newtail);
+            _Tail = _Newtail;
+            ++_First; // throws
+        }
     }
 
-    void _Attach_after(pointer _After) noexcept {
-        // Attaches the values in this insert operation after _After, and resets *this to the default initialized state
+    pointer _Attach_after(pointer _After) noexcept {
+        // Attaches the elements in *this after _After, and resets *this to the default-initialized state
+        const auto _Local_tail = _Tail;
+        if (_Local_tail == pointer{}) {
+            return _After;
+        }
 
-        // The following can't exchange because the _Construct_in_place might construct _Base
-        _Construct_in_place(*_Tail, _After->_Next);
-        _After->_Next = _Base;
-        _Destroy_in_place(_Base);
-        _Tail = _STD addressof(_Base);
+        _Construct_in_place(_Local_tail->_Next, _After->_Next);
+        _After->_Next = _Head;
+        _Tail         = pointer{};
+
+        return _Local_tail;
     }
 
-    ~_Flist_insert_after_op() {
-        _Construct_in_place(*_Tail, nullptr);
-        pointer _Subject = _Base;
+    ~_Flist_insert_after_op2() {
+        if (_Tail == pointer{}) {
+            return;
+        }
+
+        _Construct_in_place(_Tail->_Next, pointer{});
+        pointer _Subject = _Head;
         while (_Subject) {
             value_type::_Freenode(_Al, _STD exchange(_Subject, _Subject->_Next));
         }
-
-        _Destroy_in_place(_Base);
     }
 
 private:
     _Alnode& _Al;
-    pointer* _Tail; // points to not constructed pointer member in the last list node in *this
-    union {
-        pointer _Base;
-    };
+    pointer _Tail; // Points to the most recently constructed node. If pointer{}, the value of _Head is indeterminate.
+                   // _Tail->_Next is not constructed.
+    pointer _Head; // Points at the first constructed node.
 };
 
 // CLASS TEMPLATE forward_list
@@ -518,7 +548,7 @@ public:
 
     explicit forward_list(_CRT_GUARDOVERFLOW size_type _Count, const _Alloc& _Al = _Alloc())
         : _Mypair(_One_then_variadic_args_t(), _Al) { // construct list from _Count * _Ty(), optional allocator
-        _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
+        _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
         _Insert_op._Append_n(_Count);
         _Alloc_proxy();
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
@@ -526,7 +556,7 @@ public:
 
     forward_list(_CRT_GUARDOVERFLOW size_type _Count, const _Ty& _Val)
         : _Mypair(_Zero_then_variadic_args_t()) { // construct list from _Count * _Val
-        _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
+        _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
         _Insert_op._Append_n(_Count, _Val);
         _Alloc_proxy();
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
@@ -534,7 +564,7 @@ public:
 
     forward_list(_CRT_GUARDOVERFLOW size_type _Count, const _Ty& _Val, const _Alloc& _Al)
         : _Mypair(_One_then_variadic_args_t(), _Al) { // construct list from _Count * _Val, allocator
-        _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
+        _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
         _Insert_op._Append_n(_Count, _Val);
         _Alloc_proxy();
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
@@ -547,14 +577,14 @@ public:
 
     forward_list(const forward_list& _Right)
         : _Mypair(_One_then_variadic_args_t(), _Alnode_traits::select_on_container_copy_construction(_Right._Getal())) {
-        _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
+        _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
         _Insert_op._Append_range_unchecked(_Right._Unchecked_begin(), _Right._Unchecked_end());
         _Alloc_proxy();
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
     }
 
     forward_list(const forward_list& _Right, const _Alloc& _Al) : _Mypair(_One_then_variadic_args_t(), _Al) {
-        _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
+        _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
         _Insert_op._Append_range_unchecked(_Right._Unchecked_begin(), _Right._Unchecked_end());
         _Alloc_proxy();
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
@@ -563,7 +593,7 @@ public:
     template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     forward_list(_Iter _First, _Iter _Last) : _Mypair(_Zero_then_variadic_args_t()) {
         _Adl_verify_range(_First, _Last);
-        _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
+        _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
         _Insert_op._Append_range_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
         _Alloc_proxy();
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
@@ -572,7 +602,7 @@ public:
     template <class _Iter, enable_if_t<_Is_iterator_v<_Iter>, int> = 0>
     forward_list(_Iter _First, _Iter _Last, const _Alloc& _Al) : _Mypair(_One_then_variadic_args_t(), _Al) {
         _Adl_verify_range(_First, _Last);
-        _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
+        _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
         _Insert_op._Append_range_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
         _Alloc_proxy();
         _Insert_op._Attach_after(_Mypair._Myval2._Before_head());
@@ -590,7 +620,7 @@ public:
         if
             _CONSTEXPR_IF(!_Alty_traits::is_always_equal::value) {
                 if (_Getal() != _Right._Getal()) {
-                    _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
+                    _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
                     _Insert_op._Append_range_unchecked(
                         _STD make_move_iterator(_Right._Unchecked_begin()), _Default_sentinel{});
                     _Alloc_proxy();
@@ -808,7 +838,7 @@ private:
             auto _Next = _Ptr->_Next;
             if (!_Next) {
                 // list too short, insert remaining _Newsize objects initialized from _Vals...
-                _Flist_insert_after_op<_Alnode> _Insert_op(_Al);
+                _Flist_insert_after_op2<_Alnode> _Insert_op(_Al);
                 _Insert_op._Append_n(_Newsize, _Vals...);
                 _Insert_op._Attach_after(_Ptr);
                 return;
@@ -887,7 +917,7 @@ private:
         for (; _UFirst != _ULast; ++_UFirst) {
             auto _Next = _Myfirst->_Next;
             if (!_Myfirst->_Next) {
-                _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
+                _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
                 _Insert_op._Append_range_unchecked(_UFirst, _ULast);
                 _Insert_op._Attach_after(_Myfirst);
                 return;
@@ -935,10 +965,9 @@ public:
 #endif // _ITERATOR_DEBUG_LEVEL == 2
 
         if (_Count != 0) {
-            _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
-            const auto _Result_ptr = _Insert_op._Append_n(_Count, _Val);
-            _Insert_op._Attach_after(_Where._Ptr);
-            _Where._Ptr = _Result_ptr;
+            _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
+            _Insert_op._Append_n(_Count, _Val);
+            _Where._Ptr = _Insert_op._Attach_after(_Where._Ptr);
         }
 
         return _Make_iter(_Where._Ptr);
@@ -959,10 +988,9 @@ public:
             return _Make_iter(_Where._Ptr);
         }
 
-        _Flist_insert_after_op<_Alnode> _Insert_op(_Getal());
-        const auto _Result_ptr = _Insert_op._Append_range_unchecked(_UFirst, _ULast);
-        _Insert_op._Attach_after(_Where._Ptr);
-        return _Make_iter(_Result_ptr);
+        _Flist_insert_after_op2<_Alnode> _Insert_op(_Getal());
+        _Insert_op._Append_range_unchecked(_UFirst, _ULast);
+        return _Make_iter(_Insert_op._Attach_after(_Where._Ptr));
     }
 
 private:

--- a/stl/inc/list
+++ b/stl/inc/list
@@ -608,25 +608,37 @@ struct _List_node_emplace_op2 : _Alloc_construct_ptr<_Alnode> {
     }
 };
 
-// STRUCT TEMPLATE _List_node_insert_op
+// STRUCT TEMPLATE _List_node_insert_op2
 template <class _Alnode>
-struct _List_node_insert_op {
+struct _List_node_insert_op2 {
     // list insert operation which maintains exception safety
     using _Alnode_traits = allocator_traits<_Alnode>;
     using pointer        = typename _Alnode_traits::pointer;
     using size_type      = typename _Alnode_traits::size_type;
     using value_type     = typename _Alnode_traits::value_type;
 
-    explicit _List_node_insert_op(_Alnode& _Al_)
-        : _Al(_Al_), _Tail(pointer_traits<pointer>::pointer_to(_Base)), _Added(0) {}
+    explicit _List_node_insert_op2(_Alnode& _Al_) : _Al(_Al_), _Added(0) {}
 
-    _List_node_insert_op(const _List_node_insert_op&) = delete;
-    _List_node_insert_op& operator=(const _List_node_insert_op&) = delete;
+    _List_node_insert_op2(const _List_node_insert_op2&) = delete;
+    _List_node_insert_op2& operator=(const _List_node_insert_op2&) = delete;
 
     template <class... _CArgT>
     void _Append_n(size_type _Count, const _CArgT&... _Carg) {
-        // Append _Count Ts constructed from _Carg to this insert operation.
+        // Append _Count elements constructed from _Carg
+        if (_Count <= 0) {
+            return;
+        }
+
         _Alloc_construct_ptr<_Alnode> _Newnode(_Al);
+        if (_Added == 0) {
+            _Newnode._Allocate(); // throws
+            _Alnode_traits::construct(_Al, _STD addressof(_Newnode._Ptr->_Myval), _Carg...); // throws
+            _Head = _Newnode._Ptr;
+            _Tail = _Newnode._Ptr;
+            ++_Added;
+            --_Count;
+        }
+
         for (; 0 < _Count; --_Count) {
             _Newnode._Allocate(); // throws
             _Alnode_traits::construct(_Al, _STD addressof(_Newnode._Ptr->_Myval), _Carg...); // throws
@@ -641,92 +653,102 @@ struct _List_node_insert_op {
 
     template <class _InIt, class _Sentinel>
     void _Append_range_unchecked(_InIt _First, const _Sentinel _Last) {
-        // Append new elements constructed from [_First, _Last) to this insert operation.
+        // Append the values in [_First, _Last)
+        if (_First == _Last) { // throws
+            return;
+        }
+
         _Alloc_construct_ptr<_Alnode> _Newnode(_Al);
-        for (; _First != _Last; ++_First) {
+        if (_Added == 0) {
+            _Newnode._Allocate(); // throws
+            _Alnode_traits::construct(_Al, _STD addressof(_Newnode._Ptr->_Myval), *_First); // throws
+            const auto _Newhead = _STD exchange(_Newnode._Ptr, pointer{});
+            _Head               = _Newhead;
+            _Tail               = _Newhead;
+            ++_Added;
+            ++_First; // throws
+        }
+
+        while (_First != _Last) { // throws
             _Newnode._Allocate(); // throws
             _Alnode_traits::construct(_Al, _STD addressof(_Newnode._Ptr->_Myval), *_First); // throws
             _Construct_in_place(_Tail->_Next, _Newnode._Ptr);
             _Construct_in_place(_Newnode._Ptr->_Prev, _Tail);
-            _Tail = _Newnode._Ptr;
+            _Tail = _STD exchange(_Newnode._Ptr, pointer{});
             ++_Added;
+            ++_First; // throws
         }
-
-        _Newnode._Ptr = pointer{};
     }
 
     template <class _Val_types>
-    pointer _Attach_before(_List_val<_Val_types>& _My_data, const pointer _Insert_before) noexcept {
-        // Attach the elements in this insert operation before _Insert_before.
-        // If no elements were inserted, returns _Insert_before; otherwise returns a pointer
-        // to the first inserted list node.
-        // Resets *this to be empty.
-        if (_Added == 0) {
+    pointer _Attach_before(_List_val<_Val_types>& _List_data, const pointer _Insert_before) noexcept {
+        // Attach the elements in *this before _Insert_before.
+        // If *this is empty, returns _Insert_before; otherwise returns a pointer to the first inserted list node.
+        // Resets *this to the default-initialized state.
+
+        const auto _Local_added = _Added;
+        if (_Local_added == 0) {
             return _Insert_before;
         }
 
-        _My_data._Mysize += _STD exchange(_Added, size_type{0});
+        const auto _Local_head   = _Head;
+        const auto _Local_tail   = _Tail;
+        const auto _Insert_after = _Insert_before->_Prev;
 
-        _Construct_in_place(_Tail->_Next, _Insert_before); // assumed nothrow
-        const auto _Insert_after = _STD exchange(_Insert_before->_Prev, _Tail);
+        _Construct_in_place(_Local_head->_Prev, _Insert_after);
+        _Insert_after->_Next = _Local_head;
+        _Construct_in_place(_Local_tail->_Next, _Insert_before);
+        _Insert_before->_Prev = _Local_tail;
 
-        const auto _First_inserted = _Base._Next;
-        _Insert_after->_Next       = _First_inserted;
-        _First_inserted->_Prev     = _Insert_after;
-
-        _Destroy_in_place(_Base._Next);
-        _Tail = pointer_traits<pointer>::pointer_to(_Base);
-        return _First_inserted;
+        _List_data._Mysize += _Local_added;
+        _Added = 0;
+        return _Local_head;
     }
 
     template <class _Val_types>
-    void _Attach_at_end(_List_val<_Val_types>& _My_data) noexcept {
-        _Attach_before(_My_data, _My_data._Myhead);
+    void _Attach_at_end(_List_val<_Val_types>& _List_data) noexcept {
+        _Attach_before(_List_data, _List_data._Myhead);
     }
 
     template <class _Val_types>
-    void _Attach_head(_List_val<_Val_types>& _My_data) {
+    void _Attach_head(_List_val<_Val_types>& _List_data) {
         _Alloc_construct_ptr<_Alnode> _Newnode(_Al);
-        _Newnode._Allocate(); // throws, assumed nothrow hereafter
-        if (_Added == 0) {
+        _Newnode._Allocate(); // throws
+        const auto _Local_added = _STD exchange(_Added, size_type{0});
+        if (_Local_added == 0) {
             _Construct_in_place(_Newnode._Ptr->_Next, _Newnode._Ptr);
             _Construct_in_place(_Newnode._Ptr->_Prev, _Newnode._Ptr);
-            _My_data._Mysize = 0;
         } else {
-            _Construct_in_place(_Newnode._Ptr->_Next, _Base._Next);
-            _Construct_in_place(_Newnode._Ptr->_Prev, _Tail);
-            _Base._Next->_Prev = _Newnode._Ptr;
-            _Tail->_Next       = _Newnode._Ptr;
-            _My_data._Mysize   = _STD exchange(_Added, size_type{0});
-            _Destroy_in_place(_Tail->_Next);
-            _Tail = pointer_traits<pointer>::pointer_to(_Base);
+            const auto _Local_head = _Head;
+            const auto _Local_tail = _Tail;
+            _Construct_in_place(_Newnode._Ptr->_Next, _Local_head);
+            _Construct_in_place(_Newnode._Ptr->_Prev, _Local_tail);
+            _Construct_in_place(_Local_head->_Prev, _Newnode._Ptr);
+            _Construct_in_place(_Local_tail->_Next, _Newnode._Ptr);
         }
 
-        _My_data._Myhead = _Newnode._Release();
+        _List_data._Mysize = _Local_added;
+        _List_data._Myhead = _Newnode._Release();
     }
 
-    ~_List_node_insert_op() {
+    ~_List_node_insert_op2() {
         if (_Added == 0) {
             return;
         }
 
-        _Construct_in_place(_Tail->_Next, nullptr);
-        pointer _Subject = _Base._Next;
+        _Construct_in_place(_Head->_Prev, pointer{});
+        _Construct_in_place(_Tail->_Next, pointer{});
+        pointer _Subject = _Head;
         while (_Subject) {
             value_type::_Freenode(_Al, _STD exchange(_Subject, _Subject->_Next));
         }
-
-        _Destroy_in_place(_Base._Next);
     }
 
 private:
     _Alnode& _Al;
+    size_type _Added; // if 0, the values of _Head and _Tail are indeterminate
     pointer _Tail; // points to the most recently appended element; it doesn't have _Next constructed
-    size_type _Added;
-    union {
-        value_type _Base; // only ever uses _Next, other members not constructed
-                          // _Next points to the first appended element
-    };
+    pointer _Head; // points to the first appended element; it doesn't have _Prev constructed
 };
 
 template <class _Traits>
@@ -796,7 +818,7 @@ private:
     void _Construct_n(_CRT_GUARDOVERFLOW size_type _Count) {
         auto&& _Alproxy = _GET_PROXY_ALLOCATOR(_Alnode, _Getal());
         _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _Mypair._Myval2);
-        _List_node_insert_op<_Alnode> _Appended(_Getal());
+        _List_node_insert_op2<_Alnode> _Appended(_Getal());
         _Appended._Append_n(_Count);
         _Appended._Attach_head(_Mypair._Myval2);
         _Proxy._Release();
@@ -817,7 +839,7 @@ private:
     void _Construct_n(_CRT_GUARDOVERFLOW size_type _Count, const _Ty& _Val) {
         auto&& _Alproxy = _GET_PROXY_ALLOCATOR(_Alnode, _Getal());
         _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _Mypair._Myval2);
-        _List_node_insert_op<_Alnode> _Appended(_Getal());
+        _List_node_insert_op2<_Alnode> _Appended(_Getal());
         _Appended._Append_n(_Count, _Val);
         _Appended._Attach_head(_Mypair._Myval2);
         _Proxy._Release();
@@ -839,7 +861,7 @@ private:
     void _Construct_range_unchecked(_Iter _First, _Iter _Last) {
         auto&& _Alproxy = _GET_PROXY_ALLOCATOR(_Alnode, _Getal());
         _Container_proxy_ptr<_Alty> _Proxy(_Alproxy, _Mypair._Myval2);
-        _List_node_insert_op<_Alnode> _Appended(_Getal());
+        _List_node_insert_op2<_Alnode> _Appended(_Getal());
         _Appended._Append_range_unchecked(_First, _Last);
         _Appended._Attach_head(_Mypair._Myval2);
         _Proxy._Release();
@@ -1142,7 +1164,7 @@ public:
     void resize(_CRT_GUARDOVERFLOW size_type _Newsize) { // determine new length, padding with _Ty() elements as needed
         auto& _My_data = _Mypair._Myval2;
         if (_My_data._Mysize < _Newsize) { // pad to make larger
-            _List_node_insert_op<_Alnode> _Op(_Getal());
+            _List_node_insert_op2<_Alnode> _Op(_Getal());
             _Op._Append_n(_Newsize - _My_data._Mysize);
             _Op._Attach_at_end(_My_data);
         } else {
@@ -1156,7 +1178,7 @@ public:
         // determine new length, padding with _Val elements as needed
         auto& _My_data = _Mypair._Myval2;
         if (_My_data._Mysize < _Newsize) { // pad to make larger
-            _List_node_insert_op<_Alnode> _Op(_Getal());
+            _List_node_insert_op2<_Alnode> _Op(_Getal());
             _Op._Append_n(_Newsize - _My_data._Mysize, _Val);
             _Op._Attach_at_end(_My_data);
         } else {
@@ -1247,7 +1269,7 @@ private:
         auto _Old         = _Myend->_Next;
         for (;;) { // attempt to reuse a node
             if (_Old == _Myend) { // no more nodes to reuse, append the rest
-                _List_node_insert_op<_Alnode> _Op(_Getal());
+                _List_node_insert_op2<_Alnode> _Op(_Getal());
                 _Op._Append_range_unchecked(_UFirst, _ULast);
                 _Op._Attach_at_end(_Mypair._Myval2);
                 return;
@@ -1277,7 +1299,7 @@ public:
         auto _Old         = _Myend->_Next;
         for (;;) { // attempt to reuse a node
             if (_Old == _Myend) { // no more nodes to reuse, append the rest
-                _List_node_insert_op<_Alnode> _Op(_Getal());
+                _List_node_insert_op2<_Alnode> _Op(_Getal());
                 _Op._Append_n(_Count, _Val);
                 _Op._Attach_at_end(_Mypair._Myval2);
                 return;
@@ -1308,7 +1330,7 @@ public:
 #if _ITERATOR_DEBUG_LEVEL == 2
         _STL_VERIFY(_Where._Getcont() == _STD addressof(_Mypair._Myval2), "list insert iterator outside range");
 #endif // _ITERATOR_DEBUG_LEVEL == 2
-        _List_node_insert_op<_Alnode> _Op(_Getal());
+        _List_node_insert_op2<_Alnode> _Op(_Getal());
         _Op._Append_n(_Count, _Val);
         return _Make_iter(_Op._Attach_before(_Mypair._Myval2, _Where._Ptr));
     }
@@ -1319,7 +1341,7 @@ public:
         _STL_VERIFY(_Where._Getcont() == _STD addressof(_Mypair._Myval2), "list insert iterator outside range");
 #endif // _ITERATOR_DEBUG_LEVEL == 2
         _Adl_verify_range(_First, _Last);
-        _List_node_insert_op<_Alnode> _Op(_Getal());
+        _List_node_insert_op2<_Alnode> _Op(_Getal());
         _Op._Append_range_unchecked(_Get_unwrapped(_First), _Get_unwrapped(_Last));
         return _Make_iter(_Op._Attach_before(_Mypair._Myval2, _Where._Ptr));
     }


### PR DESCRIPTION
* Avoid burning unused stack space for a T in _List_node_insert_op. Resolves #973579 and GH-365.

* Change forward_list to follow a similar pattern for consistency.

* First round of code review feedback.

# Description



# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
