### PR TITLE
Add libcxx (not yet running) working towards #145. (#394)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -5,3 +5,6 @@
 	path = vcpkg
 	url = https://github.com/microsoft/vcpkg.git
 	fetchRecurseSubmodules = false
+[submodule "llvm-project"]
+	path = llvm-project
+	url = https://github.com/llvm/llvm-project.git

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -7,6 +7,7 @@
     },
     "files.eol": "\r\n",
     "files.exclude": {
+        "llvm-project": true,
         "stl/msbuild": true,
         "vcpkg": true
     },

--- a/tests/libcxx/contest.yaml
+++ b/tests/libcxx/contest.yaml
@@ -1,0 +1,16 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+---
+  tests-root: '..\..\llvm-project\libcxx\test\std'
+  skipped-test-lists-relative-to-tests-root: true
+  skipped-test-directories:
+    - 'experimental'
+  skipped-test-file-names:
+    - 'nothing_to_do.pass.cpp'
+  skipped-tests-comment-list-files:
+    - 'magic_comments.txt'
+  skipped-tests-list-files:
+    - 'skipped_tests.txt'
+  configuration-files:
+    - 'usual_matrix.lst'

--- a/tests/libcxx/magic_comments.txt
+++ b/tests/libcxx/magic_comments.txt
@@ -1,0 +1,5 @@
+// REQUIRES: c++11
+// REQUIRES: c++11 || c++14
+// REQUIRES: c++98 || c++03
+// REQUIRES: c++98 || c++03 || c++11 || c++14
+// UNSUPPORTED: c++14, c++17, c++2a

--- a/tests/libcxx/skipped_tests.txt
+++ b/tests/libcxx/skipped_tests.txt
@@ -1,0 +1,1065 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+# *** ISSUES REPORTED/KNOWN UPSTREAM ***
+# Non-Standard regex behavior.
+# "It seems likely that the test is still non-conforming due to how libc++ handles the 'w' character class."
+re\re.traits\lookup_classname.pass.cpp
+
+# These tests are extremely slow, taking over 23 minutes to execute (in debug mode, non-optimized).
+# They contain 10K^2 / 2 == 50M loops.
+input.output\iostreams.base\ios.base\ios.base.storage\iword.pass.cpp
+input.output\iostreams.base\ios.base\ios.base.storage\pword.pass.cpp
+
+# "The behavior demonstrated in this test is not meant to be standard"
+utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.ctor\null.pass.cpp
+
+# allocator<const T>.
+utilities\memory\default.allocator\allocator.ctor.pass.cpp
+
+# path::value_type is char assumptions
+input.output\file.streams\fstreams\filebuf.members\open_path.pass.cpp
+input.output\file.streams\fstreams\fstream.cons\path.pass.cpp
+input.output\file.streams\fstreams\fstream.members\open_path.pass.cpp
+input.output\file.streams\fstreams\ofstream.cons\path.pass.cpp
+input.output\file.streams\fstreams\ofstream.members\open_path.pass.cpp
+
+# This test is passing non-BidirectionalIterators to std::prev.
+# LWG-3197 "std::prev should not require BidirectionalIterator" (New)
+iterators\iterator.primitives\iterator.operations\prev.pass.cpp
+
+# Itanium ABI assumptions that current_exception and rethrow_exception don't copy the exception object
+language.support\support.exception\propagation\current_exception.pass.cpp
+language.support\support.exception\propagation\make_exception_ptr.pass.cpp
+language.support\support.exception\propagation\rethrow_exception.pass.cpp
+language.support\support.exception\except.nested\rethrow_if_nested.pass.cpp
+
+# Testing nonstandard behavior
+utilities\template.bitset\bitset.cons\string_ctor.pass.cpp
+
+
+# *** INTERACTIONS WITH CONTEST / C1XX THAT UPSTREAM LIKELY WON'T FIX ***
+# Tracked by VSO-593630 "<filesystem> Enable libcxx filesystem tests"
+# rapid-cxx-test.hpp uses pragma system_header
+# test header filesystem_test_helper.hpp emits "error: "STATIC TESTS DISABLED""
+# const_cast from const std::wstring& to std::string& is not allowed
+input.output\filesystems\class.directory_entry\directory_entry.cons\copy.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.cons\copy_assign.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.cons\move.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.cons\move_assign.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.cons\path.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.mods\assign.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.mods\refresh.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.mods\replace_filename.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.obs\file_size.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.obs\file_type_obs.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.obs\hard_link_count.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.obs\last_write_time.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.obs\status.pass.cpp
+input.output\filesystems\class.directory_entry\directory_entry.obs\symlink_status.pass.cpp
+input.output\filesystems\class.directory_iterator\directory_iterator.members\copy.pass.cpp
+input.output\filesystems\class.directory_iterator\directory_iterator.members\copy_assign.pass.cpp
+input.output\filesystems\class.directory_iterator\directory_iterator.members\ctor.pass.cpp
+input.output\filesystems\class.directory_iterator\directory_iterator.members\increment.pass.cpp
+input.output\filesystems\class.directory_iterator\directory_iterator.members\move.pass.cpp
+input.output\filesystems\class.directory_iterator\directory_iterator.members\move_assign.pass.cpp
+input.output\filesystems\class.directory_iterator\directory_iterator.nonmembers\begin_end.pass.cpp
+input.output\filesystems\class.path\synop.pass.cpp
+input.output\filesystems\class.path\path.itr\iterator.pass.cpp
+input.output\filesystems\class.path\path.member\path.append.pass.cpp
+input.output\filesystems\class.path\path.member\path.compare.pass.cpp
+input.output\filesystems\class.path\path.member\path.concat.pass.cpp
+input.output\filesystems\class.path\path.member\path.assign\braced_init.pass.cpp
+input.output\filesystems\class.path\path.member\path.assign\copy.pass.cpp
+input.output\filesystems\class.path\path.member\path.assign\move.pass.cpp
+input.output\filesystems\class.path\path.member\path.assign\source.pass.cpp
+input.output\filesystems\class.path\path.member\path.construct\copy.pass.cpp
+input.output\filesystems\class.path\path.member\path.construct\move.pass.cpp
+input.output\filesystems\class.path\path.member\path.construct\source.pass.cpp
+input.output\filesystems\class.path\path.member\path.decompose\path.decompose.pass.cpp
+input.output\filesystems\class.path\path.member\path.gen\lexically_normal.pass.cpp
+input.output\filesystems\class.path\path.member\path.gen\lexically_relative_and_proximate.pass.cpp
+input.output\filesystems\class.path\path.member\path.generic.obs\generic_string_alloc.pass.cpp
+input.output\filesystems\class.path\path.member\path.generic.obs\named_overloads.pass.cpp
+input.output\filesystems\class.path\path.member\path.modifiers\clear.pass.cpp
+input.output\filesystems\class.path\path.member\path.modifiers\make_preferred.pass.cpp
+input.output\filesystems\class.path\path.member\path.modifiers\remove_filename.pass.cpp
+input.output\filesystems\class.path\path.member\path.modifiers\replace_extension.pass.cpp
+input.output\filesystems\class.path\path.member\path.modifiers\replace_filename.pass.cpp
+input.output\filesystems\class.path\path.member\path.modifiers\swap.pass.cpp
+input.output\filesystems\class.path\path.member\path.native.obs\c_str.pass.cpp
+input.output\filesystems\class.path\path.member\path.native.obs\named_overloads.pass.cpp
+input.output\filesystems\class.path\path.member\path.native.obs\native.pass.cpp
+input.output\filesystems\class.path\path.member\path.native.obs\operator_string.pass.cpp
+input.output\filesystems\class.path\path.member\path.native.obs\string_alloc.pass.cpp
+input.output\filesystems\class.path\path.nonmember\append_op.pass.cpp
+input.output\filesystems\class.path\path.nonmember\path.factory.pass.cpp
+input.output\filesystems\class.path\path.nonmember\path.io.pass.cpp
+input.output\filesystems\class.path\path.nonmember\path.io.unicode_bug.pass.cpp
+input.output\filesystems\class.path\path.nonmember\swap.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.members\copy.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.members\copy_assign.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.members\ctor.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.members\depth.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.members\disable_recursion_pending.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.members\increment.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.members\move.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.members\move_assign.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.members\pop.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.members\recursion_pending.pass.cpp
+input.output\filesystems\class.rec.dir.itr\rec.dir.itr.nonmembers\begin_end.pass.cpp
+input.output\filesystems\fs.enum\enum.copy_options.pass.cpp
+input.output\filesystems\fs.enum\enum.directory_options.pass.cpp
+input.output\filesystems\fs.enum\enum.file_type.pass.cpp
+input.output\filesystems\fs.enum\enum.path.format.pass.cpp
+input.output\filesystems\fs.enum\enum.perms.pass.cpp
+input.output\filesystems\fs.enum\enum.perm_options.pass.cpp
+input.output\filesystems\fs.filesystem.synopsis\file_time_type.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.absolute\absolute.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.canonical\canonical.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.copy\copy.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.copy_file\copy_file.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.copy_file\copy_file_large.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.copy_symlink\copy_symlink.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.create_directories\create_directories.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.create_directory\create_directory.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.create_directory\create_directory_with_attributes.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.create_directory_symlink\create_directory_symlink.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.create_hard_link\create_hard_link.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.create_symlink\create_symlink.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.current_path\current_path.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.equivalent\equivalent.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.exists\exists.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.file_size\file_size.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.hard_lk_ct\hard_link_count.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.is_block_file\is_block_file.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.is_char_file\is_character_file.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.is_directory\is_directory.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.is_empty\is_empty.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.is_fifo\is_fifo.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.is_other\is_other.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.is_regular_file\is_regular_file.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.is_socket\is_socket.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.is_symlink\is_symlink.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.last_write_time\last_write_time.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.permissions\permissions.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.proximate\proximate.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.read_symlink\read_symlink.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.relative\relative.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.remove\remove.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.remove_all\remove_all.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.rename\rename.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.resize_file\resize_file.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.space\space.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.status\status.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.status_known\status_known.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.symlink_status\symlink_status.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.temp_dir_path\temp_directory_path.pass.cpp
+input.output\filesystems\fs.op.funcs\fs.op.weakly_canonical\weakly_canonical.pass.cpp
+
+# We need some way to turn on deprecations for tests asking for _LIBCPP_ENABLE_DEPRECATION_WARNINGS
+utilities\function.objects\negators\binary_negate.depr_in_cxx17.fail.cpp
+utilities\function.objects\negators\unary_negate.depr_in_cxx17.fail.cpp
+
+# generate_feature_test_macro_components.py needs to learn about C1XX
+language.support\support.limits\support.limits.general\new.version.pass.cpp
+language.support\support.limits\support.limits.general\type_traits.version.pass.cpp
+language.support\support.limits\support.limits.general\version.version.pass.cpp
+
+# Contest does not understand .sh tests, which must be run specially
+depr\depr.c.headers\stdint_h.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.array\new_size_align_nothrow.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.array\new_size_align.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.array\new_size_nothrow.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.array\new_size.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.array\sized_delete_array_fsizeddeallocation.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.single\new_size_align_nothrow.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.single\new_size_align.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.single\sized_delete_fsizeddeallocation.sh.cpp
+thread\thread.condition\thread.condition.condvarany\wait_terminates.sh.cpp
+
+# These tests set an allocator with a max_size() too small to default construct an unordered container
+# (due to our minimum bucket size).
+containers\unord\unord.map\max_size.pass.cpp
+containers\unord\unord.multimap\max_size.pass.cpp
+containers\unord\unord.multiset\max_size.pass.cpp
+containers\unord\unord.set\max_size.pass.cpp
+
+# Requires too great a template instantiation depth for C1XX.
+utilities\tuple\tuple.tuple\tuple.apply\apply_large_arity.pass.cpp
+
+
+# *** MISSING STL FEATURES ***
+# C++20 P0019R8 "atomic_ref"
+language.support\support.limits\support.limits.general\atomic.version.pass.cpp
+
+# C++20 P0122R7 "<span>" (and subsequent patch papers)
+containers\views\types.pass.cpp
+containers\views\span.cons\array.pass.cpp
+containers\views\span.cons\assign.pass.cpp
+containers\views\span.cons\container.pass.cpp
+containers\views\span.cons\copy.pass.cpp
+containers\views\span.cons\deduct.pass.cpp
+containers\views\span.cons\default.pass.cpp
+containers\views\span.cons\ptr_len.pass.cpp
+containers\views\span.cons\ptr_ptr.pass.cpp
+containers\views\span.cons\span.pass.cpp
+containers\views\span.cons\stdarray.pass.cpp
+containers\views\span.elem\back.pass.cpp
+containers\views\span.elem\data.pass.cpp
+containers\views\span.elem\front.pass.cpp
+containers\views\span.elem\op_idx.pass.cpp
+containers\views\span.iterators\begin.pass.cpp
+containers\views\span.iterators\end.pass.cpp
+containers\views\span.iterators\rbegin.pass.cpp
+containers\views\span.iterators\rend.pass.cpp
+containers\views\span.objectrep\as_bytes.pass.cpp
+containers\views\span.objectrep\as_writable_bytes.pass.cpp
+containers\views\span.obs\empty.pass.cpp
+containers\views\span.obs\size.pass.cpp
+containers\views\span.obs\size_bytes.pass.cpp
+containers\views\span.sub\first.pass.cpp
+containers\views\span.sub\last.pass.cpp
+containers\views\span.sub\subspan.pass.cpp
+containers\views\span.tuple\get.pass.cpp
+containers\views\span.tuple\tuple_element.pass.cpp
+containers\views\span.tuple\tuple_size.pass.cpp
+
+# C++20 P0202R3 "constexpr For <algorithm> And exchange()"
+algorithms\alg.modifying.operations\alg.copy\copy_backward.pass.cpp
+algorithms\alg.modifying.operations\alg.copy\copy_if.pass.cpp
+algorithms\alg.modifying.operations\alg.copy\copy_n.pass.cpp
+algorithms\alg.modifying.operations\alg.copy\copy.pass.cpp
+algorithms\alg.modifying.operations\alg.fill\fill_n.pass.cpp
+algorithms\alg.modifying.operations\alg.fill\fill.pass.cpp
+algorithms\alg.modifying.operations\alg.generate\generate_n.pass.cpp
+algorithms\alg.modifying.operations\alg.generate\generate.pass.cpp
+algorithms\alg.modifying.operations\alg.partitions\is_partitioned.pass.cpp
+algorithms\alg.modifying.operations\alg.partitions\partition_copy.pass.cpp
+algorithms\alg.modifying.operations\alg.partitions\partition_point.pass.cpp
+algorithms\alg.modifying.operations\alg.remove\remove_copy_if.pass.cpp
+algorithms\alg.modifying.operations\alg.remove\remove_copy.pass.cpp
+algorithms\alg.modifying.operations\alg.remove\remove_if.pass.cpp
+algorithms\alg.modifying.operations\alg.remove\remove.pass.cpp
+algorithms\alg.modifying.operations\alg.replace\replace_copy_if.pass.cpp
+algorithms\alg.modifying.operations\alg.replace\replace_copy.pass.cpp
+algorithms\alg.modifying.operations\alg.replace\replace_if.pass.cpp
+algorithms\alg.modifying.operations\alg.replace\replace.pass.cpp
+algorithms\alg.modifying.operations\alg.reverse\reverse_copy.pass.cpp
+algorithms\alg.modifying.operations\alg.transform\binary_transform.pass.cpp
+algorithms\alg.modifying.operations\alg.transform\unary_transform.pass.cpp
+algorithms\alg.modifying.operations\alg.unique\unique_copy_pred.pass.cpp
+algorithms\alg.modifying.operations\alg.unique\unique_copy.pass.cpp
+algorithms\alg.modifying.operations\alg.unique\unique_pred.pass.cpp
+algorithms\alg.modifying.operations\alg.unique\unique.pass.cpp
+algorithms\alg.nonmodifying\alg.adjacent.find\adjacent_find_pred.pass.cpp
+algorithms\alg.nonmodifying\alg.adjacent.find\adjacent_find.pass.cpp
+algorithms\alg.nonmodifying\alg.all_of\all_of.pass.cpp
+algorithms\alg.nonmodifying\alg.any_of\any_of.pass.cpp
+algorithms\alg.nonmodifying\alg.count\count_if.pass.cpp
+algorithms\alg.nonmodifying\alg.count\count.pass.cpp
+algorithms\alg.nonmodifying\alg.equal\equal_pred.pass.cpp
+algorithms\alg.nonmodifying\alg.equal\equal.pass.cpp
+algorithms\alg.nonmodifying\alg.find.end\find_end_pred.pass.cpp
+algorithms\alg.nonmodifying\alg.find.end\find_end.pass.cpp
+algorithms\alg.nonmodifying\alg.find.first.of\find_first_of_pred.pass.cpp
+algorithms\alg.nonmodifying\alg.find.first.of\find_first_of.pass.cpp
+algorithms\alg.nonmodifying\alg.find\find_if_not.pass.cpp
+algorithms\alg.nonmodifying\alg.find\find_if.pass.cpp
+algorithms\alg.nonmodifying\alg.find\find.pass.cpp
+algorithms\alg.nonmodifying\alg.foreach\for_each_n.pass.cpp
+algorithms\alg.nonmodifying\alg.foreach\test.pass.cpp
+algorithms\alg.nonmodifying\alg.is_permutation\is_permutation_pred.pass.cpp
+algorithms\alg.nonmodifying\alg.is_permutation\is_permutation.pass.cpp
+algorithms\alg.nonmodifying\alg.none_of\none_of.pass.cpp
+algorithms\alg.nonmodifying\alg.search\search_n_pred.pass.cpp
+algorithms\alg.nonmodifying\alg.search\search_n.pass.cpp
+algorithms\alg.nonmodifying\alg.search\search_pred.pass.cpp
+algorithms\alg.nonmodifying\alg.search\search.pass.cpp
+algorithms\alg.nonmodifying\mismatch\mismatch_pred.pass.cpp
+algorithms\alg.nonmodifying\mismatch\mismatch.pass.cpp
+algorithms\alg.sorting\alg.binary.search\binary.search\binary_search_comp.pass.cpp
+algorithms\alg.sorting\alg.binary.search\binary.search\binary_search.pass.cpp
+algorithms\alg.sorting\alg.binary.search\equal.range\equal_range_comp.pass.cpp
+algorithms\alg.sorting\alg.binary.search\equal.range\equal_range.pass.cpp
+algorithms\alg.sorting\alg.binary.search\lower.bound\lower_bound_comp.pass.cpp
+algorithms\alg.sorting\alg.binary.search\lower.bound\lower_bound.pass.cpp
+algorithms\alg.sorting\alg.binary.search\upper.bound\upper_bound_comp.pass.cpp
+algorithms\alg.sorting\alg.binary.search\upper.bound\upper_bound.pass.cpp
+algorithms\alg.sorting\alg.heap.operations\is.heap\is_heap_comp.pass.cpp
+algorithms\alg.sorting\alg.heap.operations\is.heap\is_heap_until_comp.pass.cpp
+algorithms\alg.sorting\alg.heap.operations\is.heap\is_heap_until.pass.cpp
+algorithms\alg.sorting\alg.heap.operations\is.heap\is_heap.pass.cpp
+algorithms\alg.sorting\alg.lex.comparison\lexicographical_compare_comp.pass.cpp
+algorithms\alg.sorting\alg.lex.comparison\lexicographical_compare.pass.cpp
+algorithms\alg.sorting\alg.set.operations\includes\includes_comp.pass.cpp
+algorithms\alg.sorting\alg.set.operations\includes\includes.pass.cpp
+algorithms\alg.sorting\alg.set.operations\set.intersection\set_intersection_comp.pass.cpp
+algorithms\alg.sorting\alg.set.operations\set.intersection\set_intersection.pass.cpp
+algorithms\alg.sorting\alg.sort\is.sorted\is_sorted_comp.pass.cpp
+algorithms\alg.sorting\alg.sort\is.sorted\is_sorted_until_comp.pass.cpp
+algorithms\alg.sorting\alg.sort\is.sorted\is_sorted_until.pass.cpp
+algorithms\alg.sorting\alg.sort\is.sorted\is_sorted.pass.cpp
+utilities\utility\exchange\exchange.pass.cpp
+
+# C++20 P0355R7 "<chrono> Calendars And Time Zones"
+utilities\time\days.pass.cpp
+utilities\time\months.pass.cpp
+utilities\time\weeks.pass.cpp
+utilities\time\years.pass.cpp
+utilities\time\time.cal\time.cal.day\types.pass.cpp
+utilities\time\time.cal\time.cal.day\time.cal.day.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.day\time.cal.day.members\decrement.pass.cpp
+utilities\time\time.cal\time.cal.day\time.cal.day.members\increment.pass.cpp
+utilities\time\time.cal\time.cal.day\time.cal.day.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.day\time.cal.day.members\plus_minus_equal.pass.cpp
+utilities\time\time.cal\time.cal.day\time.cal.day.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.day\time.cal.day.nonmembers\literals.pass.cpp
+utilities\time\time.cal\time.cal.day\time.cal.day.nonmembers\minus.pass.cpp
+utilities\time\time.cal\time.cal.day\time.cal.day.nonmembers\plus.pass.cpp
+utilities\time\time.cal\time.cal.day\time.cal.day.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.last\types.pass.cpp
+utilities\time\time.cal\time.cal.md\types.pass.cpp
+utilities\time\time.cal\time.cal.md\time.cal.md.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.md\time.cal.md.members\day.pass.cpp
+utilities\time\time.cal\time.cal.md\time.cal.md.members\month.pass.cpp
+utilities\time\time.cal\time.cal.md\time.cal.md.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.md\time.cal.md.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.md\time.cal.md.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.mdlast\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.mdlast\ctor.pass.cpp
+utilities\time\time.cal\time.cal.mdlast\month.pass.cpp
+utilities\time\time.cal\time.cal.mdlast\ok.pass.cpp
+utilities\time\time.cal\time.cal.mdlast\streaming.pass.cpp
+utilities\time\time.cal\time.cal.mdlast\types.pass.cpp
+utilities\time\time.cal\time.cal.month\types.pass.cpp
+utilities\time\time.cal\time.cal.month\time.cal.month.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.month\time.cal.month.members\decrement.pass.cpp
+utilities\time\time.cal\time.cal.month\time.cal.month.members\increment.pass.cpp
+utilities\time\time.cal\time.cal.month\time.cal.month.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.month\time.cal.month.members\plus_minus_equal.pass.cpp
+utilities\time\time.cal\time.cal.month\time.cal.month.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.month\time.cal.month.nonmembers\literals.pass.cpp
+utilities\time\time.cal\time.cal.month\time.cal.month.nonmembers\minus.pass.cpp
+utilities\time\time.cal\time.cal.month\time.cal.month.nonmembers\plus.pass.cpp
+utilities\time\time.cal\time.cal.month\time.cal.month.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.mwd\types.pass.cpp
+utilities\time\time.cal\time.cal.mwd\time.cal.mwd.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.mwd\time.cal.mwd.members\month.pass.cpp
+utilities\time\time.cal\time.cal.mwd\time.cal.mwd.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.mwd\time.cal.mwd.members\weekday_indexed.pass.cpp
+utilities\time\time.cal\time.cal.mwd\time.cal.mwd.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.mwd\time.cal.mwd.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.mwdlast\types.pass.cpp
+utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.members\month.pass.cpp
+utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.members\weekday_last.pass.cpp
+utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.mwdlast\time.cal.mwdlast.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.operators\month_day.pass.cpp
+utilities\time\time.cal\time.cal.operators\month_day_last.pass.cpp
+utilities\time\time.cal\time.cal.operators\month_weekday.pass.cpp
+utilities\time\time.cal\time.cal.operators\month_weekday_last.pass.cpp
+utilities\time\time.cal\time.cal.operators\year_month.pass.cpp
+utilities\time\time.cal\time.cal.operators\year_month_day.pass.cpp
+utilities\time\time.cal\time.cal.operators\year_month_day_last.pass.cpp
+utilities\time\time.cal\time.cal.operators\year_month_weekday.pass.cpp
+utilities\time\time.cal\time.cal.operators\year_month_weekday_last.pass.cpp
+utilities\time\time.cal\time.cal.wdidx\types.pass.cpp
+utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.members\index.pass.cpp
+utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.members\weekday.pass.cpp
+utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.wdidx\time.cal.wdidx.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.wdlast\types.pass.cpp
+utilities\time\time.cal\time.cal.wdlast\time.cal.wdlast.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.wdlast\time.cal.wdlast.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.wdlast\time.cal.wdlast.members\weekday.pass.cpp
+utilities\time\time.cal\time.cal.wdlast\time.cal.wdlast.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.wdlast\time.cal.wdlast.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.weekday\types.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.members\c_encoding.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.members\ctor.local_days.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.members\ctor.sys_days.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.members\decrement.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.members\increment.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.members\iso_encoding.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.members\operator[].pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.members\plus_minus_equal.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.nonmembers\literals.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.nonmembers\minus.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.nonmembers\plus.pass.cpp
+utilities\time\time.cal\time.cal.weekday\time.cal.weekday.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.year\types.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.members\decrement.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.members\increment.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.members\is_leap.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.members\plus_minus.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.members\plus_minus_equal.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.nonmembers\literals.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.nonmembers\minus.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.nonmembers\plus.pass.cpp
+utilities\time\time.cal\time.cal.year\time.cal.year.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.ym\types.pass.cpp
+utilities\time\time.cal\time.cal.ym\time.cal.ym.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.ym\time.cal.ym.members\month.pass.cpp
+utilities\time\time.cal\time.cal.ym\time.cal.ym.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.ym\time.cal.ym.members\plus_minus_equal_month.pass.cpp
+utilities\time\time.cal\time.cal.ym\time.cal.ym.members\plus_minus_equal_year.pass.cpp
+utilities\time\time.cal\time.cal.ym\time.cal.ym.members\year.pass.cpp
+utilities\time\time.cal\time.cal.ym\time.cal.ym.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.ym\time.cal.ym.nonmembers\minus.pass.cpp
+utilities\time\time.cal\time.cal.ym\time.cal.ym.nonmembers\plus.pass.cpp
+utilities\time\time.cal\time.cal.ym\time.cal.ym.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.ymd\types.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\ctor.local_days.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\ctor.sys_days.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\ctor.year_month_day_last.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\day.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\month.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\op.local_days.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\op.sys_days.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\plus_minus_equal_month.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\plus_minus_equal_year.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.members\year.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.nonmembers\minus.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.nonmembers\plus.pass.cpp
+utilities\time\time.cal\time.cal.ymd\time.cal.ymd.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.members\day.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.members\month.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.members\month_day_last.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.members\op_local_days.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.members\op_sys_days.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.members\plus_minus_equal_month.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.members\plus_minus_equal_year.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.members\year.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.nonmembers\minus.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.nonmembers\plus.pass.cpp
+utilities\time\time.cal\time.cal.ymdlast\time.cal.ymdlast.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\types.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\ctor.local_days.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\ctor.sys_days.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\index.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\month.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\op.local_days.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\op.sys_days.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\plus_minus_equal_month.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\plus_minus_equal_year.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\weekday.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\weekday_indexed.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.members\year.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\minus.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\plus.pass.cpp
+utilities\time\time.cal\time.cal.ymwd\time.cal.ymwd.nonmembers\streaming.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\types.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.members\ctor.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.members\month.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.members\ok.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.members\op_local_days.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.members\op_sys_days.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.members\plus_minus_equal_month.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.members\plus_minus_equal_year.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.members\weekday.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.members\year.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.nonmembers\comparisons.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.nonmembers\minus.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.nonmembers\plus.pass.cpp
+utilities\time\time.cal\time.cal.ymwdlast\time.cal.ymwdlast.nonmembers\streaming.pass.cpp
+utilities\time\time.clock\time.clock.file\consistency.pass.cpp
+utilities\time\time.clock\time.clock.file\file_time.pass.cpp
+utilities\time\time.clock\time.clock.file\now.pass.cpp
+utilities\time\time.clock\time.clock.file\rep_signed.pass.cpp
+utilities\time\time.clock\time.clock.system\local_time.types.pass.cpp
+utilities\time\time.clock\time.clock.system\sys.time.types.pass.cpp
+utilities\time\time.duration\time.duration.literals\literals1.pass.cpp
+utilities\time\time.hms\time.12\is_am.pass.cpp
+utilities\time\time.hms\time.12\is_pm.pass.cpp
+utilities\time\time.hms\time.12\make12.pass.cpp
+utilities\time\time.hms\time.12\make24.pass.cpp
+utilities\time\time.hms\time.hms.members\hours.pass.cpp
+utilities\time\time.hms\time.hms.members\is_negative.pass.cpp
+utilities\time\time.hms\time.hms.members\minutes.pass.cpp
+utilities\time\time.hms\time.hms.members\precision.pass.cpp
+utilities\time\time.hms\time.hms.members\precision_type.pass.cpp
+utilities\time\time.hms\time.hms.members\seconds.pass.cpp
+utilities\time\time.hms\time.hms.members\subseconds.pass.cpp
+utilities\time\time.hms\time.hms.members\to_duration.pass.cpp
+utilities\time\time.hms\time.hms.members\width.pass.cpp
+
+# C++20 P0415R1 "constexpr For <complex> (Again)"
+numerics\complex.number\cmplx.over\imag.pass.cpp
+numerics\complex.number\cmplx.over\real.pass.cpp
+
+# C++20 P0476R2 "<bit> bit_cast"
+language.support\support.limits\support.limits.general\bit.version.pass.cpp
+
+# C++20 P0553R4 "<bit> Rotating And Counting Functions"
+numerics\bit\bitops.count\countl_one.pass.cpp
+numerics\bit\bitops.count\countl_zero.pass.cpp
+numerics\bit\bitops.count\countr_one.pass.cpp
+numerics\bit\bitops.count\countr_zero.pass.cpp
+numerics\bit\bitops.count\popcount.pass.cpp
+numerics\bit\bitops.rot\rotl.pass.cpp
+numerics\bit\bitops.rot\rotr.pass.cpp
+
+# C++20 P0556R3 "<bit> ispow2(), ceil2(), floor2(), log2p1()"
+numerics\bit\bit.pow.two\ceil2.pass.cpp
+numerics\bit\bit.pow.two\floor2.pass.cpp
+numerics\bit\bit.pow.two\ispow2.pass.cpp
+numerics\bit\bit.pow.two\log2p1.pass.cpp
+
+# C++20 P0608R3 "Improving variant's Converting Constructor/Assignment"
+utilities\variant\variant.variant\variant.assign\conv.pass.cpp
+utilities\variant\variant.variant\variant.assign\T.pass.cpp
+utilities\variant\variant.variant\variant.ctor\conv.pass.cpp
+utilities\variant\variant.variant\variant.ctor\T.pass.cpp
+
+# C++20 P0768R1 "Library Support for the Spaceship (Comparison) Operator"
+language.support\support.limits\support.limits.general\compare.version.pass.cpp
+
+# C++20 P0811R2 "midpoint(), lerp()"
+language.support\support.limits\support.limits.general\numeric.version.pass.cpp
+numerics\c.math\c.math.lerp\c.math.lerp.pass.cpp
+
+# C++20 P0879R0 "constexpr For Swapping Functions"
+algorithms\alg.modifying.operations\alg.swap\iter_swap.pass.cpp
+algorithms\alg.modifying.operations\alg.swap\swap_ranges.pass.cpp
+language.support\support.limits\support.limits.general\algorithm.version.pass.cpp
+utilities\utility\utility.swap\swap.pass.cpp
+utilities\utility\utility.swap\swap_array.pass.cpp
+
+# C++20 P0896R4 "<ranges>"
+language.support\support.limits\support.limits.general\algorithm.version.pass.cpp
+language.support\support.limits\support.limits.general\functional.version.pass.cpp
+language.support\support.limits\support.limits.general\iterator.version.pass.cpp
+language.support\support.limits\support.limits.general\memory.version.pass.cpp
+
+# C++20 P1006R1 "constexpr For pointer_traits<T*>::pointer_to()"
+utilities\memory\pointer.traits\pointer_to.pass.cpp
+
+# C++20 P1023R0 "constexpr For std::array Comparisons"
+containers\sequences\array\compare.pass.cpp
+
+# C++20 P1032R1 "Miscellaneous constexpr"
+language.support\support.limits\support.limits.general\array.version.pass.cpp
+language.support\support.limits\support.limits.general\functional.version.pass.cpp
+language.support\support.limits\support.limits.general\iterator.version.pass.cpp
+language.support\support.limits\support.limits.general\string_view.version.pass.cpp
+language.support\support.limits\support.limits.general\tuple.version.pass.cpp
+language.support\support.limits\support.limits.general\utility.version.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char\assign3.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char\copy.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char\move.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char16_t\assign3.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char16_t\copy.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char16_t\move.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char32_t\assign3.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char32_t\copy.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char32_t\move.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char8_t\assign3.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char8_t\copy.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.char8_t\move.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.wchar.t\assign3.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.wchar.t\copy.pass.cpp
+strings\char.traits\char.traits.specializations\char.traits.specializations.wchar.t\move.pass.cpp
+
+
+# *** MISSING COMPILER FEATURES ***
+# C++20 P0722R3 "Efficient sized delete for variable sized classes"
+language.support\support.dynamic\destroying_delete_t_declaration.pass.cpp
+language.support\support.dynamic\destroying_delete_t.pass.cpp
+
+
+# *** MISSING LWG ISSUE RESOLUTIONS ***
+# LWG-2532 "Satisfying a promise at thread exit" (Open)
+# WCFB02 implements the proposed resolution for this issue
+thread\futures\futures.promise\set_exception_at_thread_exit.pass.cpp
+thread\futures\futures.promise\set_lvalue_at_thread_exit.pass.cpp
+thread\futures\futures.promise\set_rvalue_at_thread_exit.pass.cpp
+thread\futures\futures.promise\set_value_at_thread_exit_const.pass.cpp
+thread\futures\futures.promise\set_value_at_thread_exit_void.pass.cpp
+thread\futures\futures.task\futures.task.members\make_ready_at_thread_exit.pass.cpp
+
+
+# *** C1XX COMPILER BUGS ***
+# Compiler bug: VSO-120957 "alignas by-value parameters should be permitted"
+utilities\meta\meta.trans\meta.trans.other\aligned_storage.pass.cpp
+
+# Compiler bug: VSO-106654 "error C2580 "multiple versions of a defaulted special member functions are not allowed" is bogus and ungrammatical"
+utilities\tuple\tuple.tuple\tuple.cnstr\test_lazy_sfinae.pass.cpp
+
+# Compiler bug: VSO-406936 "is_constructible<int&&, double&> and is_constructible<const int&, ExplicitTo<int&&>> should be true"
+utilities\meta\meta.unary\meta.unary.prop\is_constructible.pass.cpp
+
+
+# *** CLANG COMPILER BUGS ***
+# LLVM-33230 "Clang on Windows should define __STDCPP_THREADS__ to be 1"
+thread\macro.pass.cpp
+
+# <concepts> hasn't been enabled for Clang yet.
+iterators\iterator.primitives\iterator.traits\pointer.pass.cpp
+iterators\iterator.primitives\std.iterator.tags\contiguous_iterator_tag.pass.cpp
+
+
+# *** CLANG ISSUES, NOT YET ANALYZED ***
+# Clang doesn't enable sized deallocation by default. Should we add -fsized-deallocation or do something else?
+language.support\support.dynamic\new.delete\new.delete.array\sized_delete_array_fsizeddeallocation.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.array\sized_delete_array14.pass.cpp
+language.support\support.dynamic\new.delete\new.delete.single\sized_delete_fsizeddeallocation.sh.cpp
+language.support\support.dynamic\new.delete\new.delete.single\sized_delete14.pass.cpp
+
+# Not yet analyzed. Clang apparently defines platform macros differently from C1XX.
+language.support\support.limits\limits\numeric.limits.members\traps.pass.cpp
+
+
+# *** STL BUGS ***
+# STL bug: VSO-121977 "<locale>: the enum value of std::money_base is not correct[libcxx]"
+localization\locale.categories\category.monetary\locale.moneypunct\money_base.pass.cpp
+
+# STL Bug: VSO-595631 <fstream> basic_filebuf doesn't comply with setbuf(0,0) requirement in the standard
+input.output\file.streams\fstreams\filebuf.virtuals\overflow.pass.cpp
+input.output\file.streams\fstreams\filebuf.virtuals\underflow.pass.cpp
+
+# STL bug: We don't have tgmath.h.
+depr\depr.c.headers\tgmath_h.pass.cpp
+
+# STL bug: Our inheritance implementation is allowing this to compile when it shouldn't.
+numerics\complex.number\complex.special\double_long_double_implicit.fail.cpp
+numerics\complex.number\complex.special\float_double_implicit.fail.cpp
+numerics\complex.number\complex.special\float_long_double_implicit.fail.cpp
+
+# STL bug: regex_traits::transform() isn't following the Standard.
+re\re.traits\transform.pass.cpp
+
+# STL bug: Incorrect return types.
+numerics\complex.number\cmplx.over\conj.pass.cpp
+numerics\complex.number\cmplx.over\pow.pass.cpp
+numerics\complex.number\cmplx.over\proj.pass.cpp
+
+# STL bug: Missing <valarray> assignment operators.
+numerics\numarray\template.mask.array\mask.array.assign\mask_array.pass.cpp
+numerics\numarray\template.slice.array\slice.arr.assign\slice_array.pass.cpp
+
+# STL bug: We allow fill() and swap() for array<const T, 0>.
+containers\sequences\array\array.fill\fill.fail.cpp
+containers\sequences\array\array.swap\swap.fail.cpp
+
+# STL bug: VSO-207715 We reject array<NoDefault, 0>.
+containers\sequences\array\array.cons\default.pass.cpp
+containers\sequences\array\array.cons\implicit_copy.pass.cpp
+containers\sequences\array\array.data\data_const.pass.cpp
+containers\sequences\array\array.data\data.pass.cpp
+containers\sequences\array\begin.pass.cpp
+
+# STL bug: string_view doesn't enforce "non-array trivial standard-layout", related to LWG-3034.
+strings\string.view\char.bad.fail.cpp
+
+# Predicate count assertions - IDL2 is slightly bending the Standard's rules here.
+algorithms\alg.sorting\alg.heap.operations\make.heap\make_heap_comp.pass.cpp
+algorithms\alg.sorting\alg.merge\inplace_merge_comp.pass.cpp
+algorithms\alg.sorting\alg.min.max\minmax_init_list_comp.pass.cpp
+
+# STL bug: We don't match strtod / strtof when doing field extraction for hexfloats, or special cases like inf
+localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_double.pass.cpp
+localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_float.pass.cpp
+localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_long_double.pass.cpp
+
+# STL bug: We don't match numpunct groups correctly in do_get
+localization\locale.categories\category.numeric\locale.num.get\facet.num.get.members\get_long.pass.cpp
+
+# STL test bug: We don't have the locale names libcxx wants specialized in platform_support.hpp
+# More bugs may be uncovered when the locale names are present.
+input.output\iostreams.base\ios\basic.ios.members\move.pass.cpp
+localization\locale.categories\category.collate\locale.collate.byname\compare.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\is_1.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\is_many.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\narrow_1.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\narrow_many.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\scan_is.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\scan_not.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\widen_1.pass.cpp
+localization\locale.categories\category.ctype\locale.ctype.byname\widen_many.pass.cpp
+localization\locale.categories\category.monetary\locale.moneypunct.byname\curr_symbol.pass.cpp
+localization\locale.categories\category.monetary\locale.moneypunct.byname\decimal_point.pass.cpp
+localization\locale.categories\category.monetary\locale.moneypunct.byname\grouping.pass.cpp
+localization\locale.categories\category.monetary\locale.moneypunct.byname\neg_format.pass.cpp
+localization\locale.categories\category.monetary\locale.moneypunct.byname\negative_sign.pass.cpp
+localization\locale.categories\category.monetary\locale.moneypunct.byname\pos_format.pass.cpp
+localization\locale.categories\category.monetary\locale.moneypunct.byname\thousands_sep.pass.cpp
+localization\locale.categories\category.time\locale.time.get.byname\get_date.pass.cpp
+localization\locale.categories\category.time\locale.time.get.byname\get_date_wide.pass.cpp
+localization\locale.categories\category.time\locale.time.get.byname\get_monthname.pass.cpp
+localization\locale.categories\category.time\locale.time.get.byname\get_monthname_wide.pass.cpp
+localization\locale.categories\category.time\locale.time.get.byname\get_one.pass.cpp
+localization\locale.categories\category.time\locale.time.get.byname\get_one_wide.pass.cpp
+localization\locale.categories\category.time\locale.time.get.byname\get_weekday.pass.cpp
+localization\locale.categories\category.time\locale.time.get.byname\get_weekday_wide.pass.cpp
+localization\locale.categories\category.time\locale.time.put.byname\put1.pass.cpp
+localization\locale.categories\facet.numpunct\locale.numpunct.byname\grouping.pass.cpp
+localization\locale.categories\facet.numpunct\locale.numpunct.byname\thousands_sep.pass.cpp
+
+# STL Bug? Our wbuffer_convert does not implement seek. [depr.conversions.buffer] is completely underspecified.
+localization\locales\locale.convenience\conversions\conversions.buffer\seekoff.pass.cpp
+
+# STL Bug: We aren't properly SFINAEing chrono operators
+# https://github.com/llvm/llvm-project/commit/efa6d803c624f9251d0ab7881122501bb9d27368
+utilities\time\time.duration\time.duration.nonmember\op_divide_rep.pass.cpp
+utilities\time\time.duration\time.duration.nonmember\op_mod_rep.pass.cpp
+
+# STL Bug: error_category's default ctor isn't constexpr. (Should be fixed in vNext.)
+diagnostics\syserr\syserr.errcat\syserr.errcat.nonvirtuals\default_ctor.pass.cpp
+
+# STL Bug: future incorrectly uses copy assignment instead of copy construction in set_value. (Should be fixed in vNext.)
+thread\futures\futures.promise\set_value_const.pass.cpp
+
+
+# *** CRT BUGS ***
+# We're permanently missing aligned_alloc().
+depr\depr.c.headers\stdlib_h.pass.cpp
+language.support\support.runtime\cstdlib.pass.cpp
+
+# OS-11107628 "_Exit allows cleanup in other DLLs"
+thread\thread.threads\thread.thread.class\thread.thread.assign\move2.pass.cpp
+thread\thread.threads\thread.thread.class\thread.thread.member\join.pass.cpp
+
+
+# *** LIKELY BOGUS TESTS ***
+# Test bug. See VSO-521345 "<cmath> We're missing integral overloads for some math.h functions, including isfinite"
+depr\depr.c.headers\math_h.pass.cpp
+numerics\c.math\cmath.pass.cpp
+
+# Test bug after LWG-2899 "is_(nothrow_)move_constructible and tuple, optional and unique_ptr" was accepted.
+utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.asgn\move_convert.pass.cpp
+utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.asgn\move_convert.runtime.pass.cpp
+utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.asgn\move_convert.single.pass.cpp
+utilities\smartptr\unique.ptr\unique.ptr.class\unique.ptr.asgn\move.pass.cpp
+
+# Test bug after LWG-3257 "Missing feature testing macro update from P0858" was accepted.
+language.support\support.limits\support.limits.general\string.version.pass.cpp
+
+# Test bug. See LWG-3099 "is_assignable<Incomplete&, Incomplete&>"
+utilities\utility\pairs\pairs.pair\assign_pair.pass.cpp
+
+# Not yet analyzed, likely bogus tests. Appears to be timing assumptions.
+thread\futures\futures.async\async.pass.cpp
+thread\futures\futures.shared_future\wait_for.pass.cpp
+thread\futures\futures.unique_future\wait_for.pass.cpp
+thread\thread.condition\thread.condition.condvar\notify_all.pass.cpp
+thread\thread.condition\thread.condition.condvar\notify_one.pass.cpp
+thread\thread.condition\thread.condition.condvar\wait_for_pred.pass.cpp
+thread\thread.condition\thread.condition.condvar\wait_for.pass.cpp
+thread\thread.condition\thread.condition.condvar\wait_until_pred.pass.cpp
+thread\thread.condition\thread.condition.condvar\wait_until.pass.cpp
+thread\thread.condition\thread.condition.condvarany\notify_all.pass.cpp
+thread\thread.condition\thread.condition.condvarany\notify_one.pass.cpp
+thread\thread.condition\thread.condition.condvarany\wait_for_pred.pass.cpp
+thread\thread.condition\thread.condition.condvarany\wait_for.pass.cpp
+thread\thread.condition\thread.condition.condvarany\wait_until_pred.pass.cpp
+thread\thread.condition\thread.condition.condvarany\wait_until.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.guard\adopt_lock.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.guard\mutex.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.shared\thread.lock.shared.cons\mutex_duration.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.shared\thread.lock.shared.cons\mutex_time_point.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.shared\thread.lock.shared.cons\mutex_try_to_lock.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.shared\thread.lock.shared.cons\mutex.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.shared\thread.lock.shared.locking\lock.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.unique\thread.lock.unique.cons\mutex_duration.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.unique\thread.lock.unique.cons\mutex_time_point.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.unique\thread.lock.unique.cons\mutex_try_to_lock.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.unique\thread.lock.unique.cons\mutex.pass.cpp
+thread\thread.mutex\thread.lock\thread.lock.unique\thread.lock.unique.locking\lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.mutex.requirements.mutex\thread.mutex.class\lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.mutex.requirements.mutex\thread.mutex.class\try_lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.mutex.requirements.mutex\thread.mutex.recursive\lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.mutex.requirements.mutex\thread.mutex.recursive\try_lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.shared_mutex.requirements\thread.shared_mutex.class\lock_shared.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.shared_mutex.requirements\thread.shared_mutex.class\lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.shared_mutex.requirements\thread.shared_mutex.class\try_lock_shared.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.shared_mutex.requirements\thread.shared_mutex.class\try_lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.sharedtimedmutex.requirements\thread.sharedtimedmutex.class\lock_shared.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.sharedtimedmutex.requirements\thread.sharedtimedmutex.class\lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.sharedtimedmutex.requirements\thread.sharedtimedmutex.class\try_lock_for.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.sharedtimedmutex.requirements\thread.sharedtimedmutex.class\try_lock_shared_for.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.sharedtimedmutex.requirements\thread.sharedtimedmutex.class\try_lock_shared_until.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.sharedtimedmutex.requirements\thread.sharedtimedmutex.class\try_lock_shared.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.sharedtimedmutex.requirements\thread.sharedtimedmutex.class\try_lock_until.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.sharedtimedmutex.requirements\thread.sharedtimedmutex.class\try_lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.timedmutex.requirements\thread.timedmutex.class\lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.timedmutex.requirements\thread.timedmutex.class\try_lock_for.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.timedmutex.requirements\thread.timedmutex.class\try_lock_until.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.timedmutex.requirements\thread.timedmutex.class\try_lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.timedmutex.requirements\thread.timedmutex.recursive\lock.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.timedmutex.requirements\thread.timedmutex.recursive\try_lock_for.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.timedmutex.requirements\thread.timedmutex.recursive\try_lock_until.pass.cpp
+thread\thread.mutex\thread.mutex.requirements\thread.timedmutex.requirements\thread.timedmutex.recursive\try_lock.pass.cpp
+thread\thread.threads\thread.thread.class\thread.thread.destr\dtor.pass.cpp
+thread\thread.threads\thread.thread.class\thread.thread.member\detach.pass.cpp
+thread\thread.threads\thread.thread.this\sleep_until.pass.cpp
+
+# Not yet analyzed, likely bogus tests. Various assertions, probably POSIX assumptions.
+diagnostics\syserr\syserr.compare\eq_error_code_error_code.pass.cpp
+diagnostics\syserr\syserr.errcat\syserr.errcat.derived\message.pass.cpp
+diagnostics\syserr\syserr.errcat\syserr.errcat.objects\system_category.pass.cpp
+diagnostics\syserr\syserr.syserr\syserr.syserr.members\ctor_error_code_const_char_pointer.pass.cpp
+diagnostics\syserr\syserr.syserr\syserr.syserr.members\ctor_error_code_string.pass.cpp
+diagnostics\syserr\syserr.syserr\syserr.syserr.members\ctor_error_code.pass.cpp
+diagnostics\syserr\syserr.syserr\syserr.syserr.members\ctor_int_error_category_const_char_pointer.pass.cpp
+diagnostics\syserr\syserr.syserr\syserr.syserr.members\ctor_int_error_category_string.pass.cpp
+diagnostics\syserr\syserr.syserr\syserr.syserr.members\ctor_int_error_category.pass.cpp
+
+# libc++ disagrees with libstdc++ and MSVC++ on whether setstate calls during I/O that throw set failbit; see open issue LWG-2349
+input.output\iostream.format\input.streams\istream.unformatted\get_pointer_size_chart.pass.cpp
+input.output\iostream.format\input.streams\istream.unformatted\get_pointer_size.pass.cpp
+
+# Sensitive to implementation details. Assertion failed: test_alloc_base::count == expected_num_allocs
+containers\container.requirements\container.requirements.general\allocator_move.pass.cpp
+
+# Tests std::weak_equality/strong_equality which were removed by P1959R0
+language.support\cmp\cmp.common\common_comparison_category.pass.cpp
+language.support\cmp\cmp.partialord\partialord.pass.cpp
+language.support\cmp\cmp.strongeq\cmp.strongeq.pass.cpp
+language.support\cmp\cmp.strongord\strongord.pass.cpp
+language.support\cmp\cmp.weakeq\cmp.weakeq.pass.cpp
+language.support\cmp\cmp.weakord\weakord.pass.cpp
+
+
+# *** LIKELY STL BUGS ***
+# Not yet analyzed, likely STL bugs. Assertions and other runtime failures.
+numerics\rand\rand.dis\rand.dist.bern\rand.dist.bern.bin\eval_param.pass.cpp
+numerics\rand\rand.dis\rand.dist.bern\rand.dist.bern.bin\eval.pass.cpp
+numerics\rand\rand.dis\rand.dist.bern\rand.dist.bern.geo\eval_param.pass.cpp
+numerics\rand\rand.dis\rand.dist.bern\rand.dist.bern.geo\eval.pass.cpp
+numerics\rand\rand.dis\rand.dist.bern\rand.dist.bern.negbin\eval_param.pass.cpp
+numerics\rand\rand.dis\rand.dist.bern\rand.dist.bern.negbin\eval.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.cauchy\max.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.cauchy\min.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.chisq\max.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.chisq\min.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.f\max.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.lognormal\eval_param.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.lognormal\eval.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.lognormal\max.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.lognormal\min.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.normal\max.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.normal\min.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.t\eval_param.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.t\eval.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.t\max.pass.cpp
+numerics\rand\rand.dis\rand.dist.norm\rand.dist.norm.t\min.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.exp\max.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.extreme\eval_param.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.extreme\eval.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.extreme\max.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.extreme\min.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.gamma\eq.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.gamma\eval_param.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.gamma\eval.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.gamma\max.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.gamma\min.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.poisson\eval_param.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.poisson\eval.pass.cpp
+numerics\rand\rand.dis\rand.dist.pois\rand.dist.pois.weibull\max.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.pconst\ctor_init_func.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.pconst\ctor_iterator.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.pconst\eval.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.pconst\param_ctor_init_func.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.pconst\param_ctor_iterator.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\ctor_default.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\ctor_func.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\ctor_init_func.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\ctor_iterator.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\ctor_param.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\eval_param.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\eval.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\param_ctor_default.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\param_ctor_func.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\param_ctor_init_func.pass.cpp
+numerics\rand\rand.dis\rand.dist.samp\rand.dist.samp.plinear\param_ctor_iterator.pass.cpp
+numerics\rand\rand.dis\rand.dist.uni\rand.dist.uni.real\param_ctor.pass.cpp
+
+# Not yet analyzed, likely STL bugs. Various assertions.
+re\re.alg\re.alg.match\awk.pass.cpp
+re\re.alg\re.alg.match\basic.pass.cpp
+re\re.alg\re.alg.match\ecma.pass.cpp
+re\re.alg\re.alg.match\extended.pass.cpp
+re\re.alg\re.alg.search\awk.pass.cpp
+re\re.alg\re.alg.search\basic.pass.cpp
+re\re.alg\re.alg.search\ecma.pass.cpp
+re\re.alg\re.alg.search\extended.pass.cpp
+re\re.alg\re.alg.search\no_update_pos.pass.cpp
+re\re.badexp\regex_error.pass.cpp
+re\re.const\re.synopt\syntax_option_type.pass.cpp
+re\re.grammar\excessive_brace_count.pass.cpp
+re\re.regex\re.regex.construct\bad_backref.pass.cpp
+re\re.regex\re.regex.construct\bad_escape.pass.cpp
+re\re.regex\re.regex.construct\bad_range.pass.cpp
+re\re.regex\re.regex.construct\default.pass.cpp
+re\re.regex\re.regex.nonmemb\re.regex.nmswap\swap.pass.cpp
+re\re.regex\re.regex.swap\swap.pass.cpp
+re\re.traits\lookup_collatename.pass.cpp
+re\re.traits\transform_primary.pass.cpp
+
+# Not yet analyzed, likely STL bugs. Various assertions.
+numerics\complex.number\complex.member.ops\divide_equal_complex.pass.cpp
+numerics\complex.number\complex.ops\complex_divide_complex.pass.cpp
+numerics\complex.number\complex.ops\complex_times_complex.pass.cpp
+numerics\complex.number\complex.ops\scalar_divide_complex.pass.cpp
+numerics\complex.number\complex.transcendentals\acos.pass.cpp
+numerics\complex.number\complex.transcendentals\acosh.pass.cpp
+numerics\complex.number\complex.transcendentals\asin.pass.cpp
+numerics\complex.number\complex.transcendentals\asinh.pass.cpp
+numerics\complex.number\complex.transcendentals\atanh.pass.cpp
+numerics\complex.number\complex.transcendentals\cos.pass.cpp
+numerics\complex.number\complex.transcendentals\cosh.pass.cpp
+numerics\complex.number\complex.transcendentals\exp.pass.cpp
+numerics\complex.number\complex.transcendentals\log10.pass.cpp
+numerics\complex.number\complex.transcendentals\pow_complex_complex.pass.cpp
+numerics\complex.number\complex.transcendentals\pow_complex_scalar.pass.cpp
+numerics\complex.number\complex.transcendentals\pow_scalar_complex.pass.cpp
+numerics\complex.number\complex.transcendentals\sin.pass.cpp
+numerics\complex.number\complex.transcendentals\sinh.pass.cpp
+numerics\complex.number\complex.transcendentals\sqrt.pass.cpp
+numerics\complex.number\complex.transcendentals\tanh.pass.cpp
+numerics\complex.number\complex.value.ops\norm.pass.cpp
+numerics\complex.number\complex.value.ops\polar.pass.cpp
+numerics\complex.number\complex.value.ops\proj.pass.cpp
+
+# Not yet analyzed, likely STL bugs. Many various assertions.
+localization\locale.categories\category.ctype\facet.ctype.special\facet.ctype.char.statics\classic_table.pass.cpp
+localization\locale.categories\category.monetary\locale.money.get\locale.money.get.members\get_long_double_en_US.pass.cpp
+localization\locale.categories\category.monetary\locale.money.get\locale.money.get.members\get_long_double_fr_FR.pass.cpp
+localization\locale.categories\category.monetary\locale.money.get\locale.money.get.members\get_long_double_ru_RU.pass.cpp
+localization\locale.categories\category.monetary\locale.money.get\locale.money.get.members\get_long_double_zh_CN.pass.cpp
+localization\locale.categories\category.monetary\locale.money.get\locale.money.get.members\get_string_en_US.pass.cpp
+localization\locale.categories\category.monetary\locale.money.put\locale.money.put.members\put_long_double_en_US.pass.cpp
+localization\locale.categories\category.monetary\locale.money.put\locale.money.put.members\put_long_double_fr_FR.pass.cpp
+localization\locale.categories\category.monetary\locale.money.put\locale.money.put.members\put_long_double_ru_RU.pass.cpp
+localization\locale.categories\category.monetary\locale.money.put\locale.money.put.members\put_long_double_zh_CN.pass.cpp
+localization\locale.categories\category.monetary\locale.money.put\locale.money.put.members\put_string_en_US.pass.cpp
+localization\locale.categories\category.monetary\locale.moneypunct\locale.moneypunct.members\decimal_point.pass.cpp
+localization\locale.categories\category.monetary\locale.moneypunct\locale.moneypunct.members\thousands_sep.pass.cpp
+localization\locale.categories\category.numeric\locale.nm.put\facet.num.put.members\put_double.pass.cpp
+localization\locale.categories\category.numeric\locale.nm.put\facet.num.put.members\put_long_double.pass.cpp
+localization\locale.categories\category.time\locale.time.get\locale.time.get.members\get_monthname_wide.pass.cpp
+localization\locale.categories\category.time\locale.time.get\locale.time.get.members\get_monthname.pass.cpp
+localization\locale.categories\category.time\locale.time.get\locale.time.get.members\get_one.pass.cpp
+localization\locale.categories\category.time\locale.time.get\locale.time.get.members\get_time_wide.pass.cpp
+localization\locale.categories\category.time\locale.time.get\locale.time.get.members\get_time.pass.cpp
+localization\locale.categories\category.time\locale.time.get\locale.time.get.members\get_weekday_wide.pass.cpp
+localization\locale.categories\category.time\locale.time.get\locale.time.get.members\get_weekday.pass.cpp
+localization\locale.categories\category.time\locale.time.put\locale.time.put.members\put2.pass.cpp
+localization\locale.stdcvt\codecvt_utf16_in.pass.cpp
+localization\locale.stdcvt\codecvt_utf16_length.pass.cpp
+localization\locale.stdcvt\codecvt_utf16_max_length.pass.cpp
+localization\locale.stdcvt\codecvt_utf16_out.pass.cpp
+localization\locale.stdcvt\codecvt_utf16.pass.cpp
+localization\locale.stdcvt\codecvt_utf8_in.pass.cpp
+localization\locale.stdcvt\codecvt_utf8_length.pass.cpp
+localization\locale.stdcvt\codecvt_utf8_max_length.pass.cpp
+localization\locale.stdcvt\codecvt_utf8_out.pass.cpp
+localization\locale.stdcvt\codecvt_utf8_utf16_in.pass.cpp
+localization\locale.stdcvt\codecvt_utf8_utf16_length.pass.cpp
+localization\locale.stdcvt\codecvt_utf8_utf16_max_length.pass.cpp
+localization\locale.stdcvt\codecvt_utf8_utf16_out.pass.cpp
+localization\locale.stdcvt\codecvt_utf8.pass.cpp
+localization\locales\locale.convenience\conversions\conversions.buffer\overflow.pass.cpp
+localization\locales\locale.convenience\conversions\conversions.buffer\pbackfail.pass.cpp
+localization\locales\locale.convenience\conversions\conversions.buffer\underflow.pass.cpp
+localization\locales\locale.convenience\conversions\conversions.string\ctor_err_string.pass.cpp
+
+# Not yet analyzed, likely STL bugs. Various assertions.
+input.output\iostream.format\ext.manip\get_money.pass.cpp
+input.output\iostream.format\ext.manip\put_money.pass.cpp
+input.output\iostreams.base\ios\basic.ios.members\copyfmt.pass.cpp
+
+# Not yet analyzed, likely STL bugs. Assertion failed: os.str() == a
+numerics\rand\rand.adapt\rand.adapt.disc\ctor_result_type.pass.cpp
+numerics\rand\rand.adapt\rand.adapt.disc\ctor_sseq.pass.cpp
+numerics\rand\rand.adapt\rand.adapt.ibits\ctor_result_type.pass.cpp
+numerics\rand\rand.adapt\rand.adapt.ibits\ctor_sseq.pass.cpp
+numerics\rand\rand.eng\rand.eng.mers\ctor_result_type.pass.cpp
+numerics\rand\rand.eng\rand.eng.mers\ctor_sseq.pass.cpp
+numerics\rand\rand.eng\rand.eng.sub\ctor_result_type.pass.cpp
+numerics\rand\rand.eng\rand.eng.sub\ctor_sseq.pass.cpp
+
+# Not yet analyzed, likely STL bugs. Assertion failed: e1 == e2
+numerics\rand\rand.adapt\rand.adapt.disc\io.pass.cpp
+numerics\rand\rand.adapt\rand.adapt.ibits\io.pass.cpp
+numerics\rand\rand.eng\rand.eng.sub\io.pass.cpp
+
+# Likely STL bug: Looks like we shouldn't be using assignment.
+thread\futures\futures.promise\set_rvalue.pass.cpp
+
+# Possible STL bugs in pair and tuple.
+utilities\tuple\tuple.tuple\tuple.cnstr\PR23256_constrain_UTypes_ctor.pass.cpp
+utilities\tuple\tuple.tuple\tuple.cnstr\PR31384.pass.cpp
+
+# Likely STL bugs in mersenne_twister; also fails at runtime
+# random(1186,26):  error: constexpr variable '_WMSK' must be initialized by a constant expression
+#    static constexpr _Ty _WMSK = ~((~_Ty(0) << (_Wx - 1)) << 1);
+#                         ^       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+numerics\rand\rand.eng\rand.eng.mers\ctor_sseq_all_zero.pass.cpp
+
+# Bugs/questionable choices in codecvt<char(16|32)_t, char, mbstate_t>, which we probably will not fix since
+# (1) they are deprecated, and (2) we don't want to break existing users.
+localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\char16_t_max_length.pass.cpp
+localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\char16_t_unshift.pass.cpp
+localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\char32_t_encoding.pass.cpp
+localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\char32_t_max_length.pass.cpp
+
+# Likely STL bug in <chrono>: "result type of conditional expression is ambiguous"
+utilities\time\time.duration\time.duration.alg\abs.pass.cpp
+
+
+# *** NOT YET ANALYZED ***
+# Not yet analyzed. Asserting about alloc_count.
+thread\futures\futures.promise\alloc_ctor.pass.cpp
+thread\futures\futures.promise\move_assign.pass.cpp
+thread\futures\futures.promise\move_ctor.pass.cpp
+thread\futures\futures.promise\swap.pass.cpp
+thread\futures\futures.shared_future\dtor.pass.cpp
+thread\futures\futures.unique_future\dtor.pass.cpp
+
+# Not yet analyzed. libc++ seems to have a different opinion about what tuple_size<const void> should do.
+utilities\tuple\tuple.tuple\tuple.helper\tuple_size_incomplete.pass.cpp
+utilities\tuple\tuple.tuple\tuple.helper\tuple_size_structured_bindings.pass.cpp
+
+# Not yet analyzed. Possibly testing nonstandard deduction guides.
+containers\associative\map\map.cons\deduct_const.pass.cpp
+containers\associative\multimap\multimap.cons\deduct_const.pass.cpp
+containers\unord\unord.map\unord.map.cnstr\deduct_const.pass.cpp
+containers\unord\unord.multimap\unord.multimap.cnstr\deduct.pass.cpp
+containers\unord\unord.multimap\unord.multimap.cnstr\deduct_const.pass.cpp
+utilities\tuple\tuple.tuple\tuple.cnstr\deduct.pass.cpp
+
+# Not yet analyzed. Assertion failed: m1.empty()
+containers\associative\map\map.cons\move_assign.pass.cpp
+containers\associative\multimap\multimap.cons\move_assign.pass.cpp
+containers\associative\multiset\multiset.cons\move_assign.pass.cpp
+containers\associative\set\set.cons\move_assign.pass.cpp
+
+# Not yet analyzed. Assertion failed: controller->check<Args&&...>()
+containers\associative\map\map.modifiers\insert_and_emplace_allocator_requirements.pass.cpp
+containers\associative\set\insert_and_emplace_allocator_requirements.pass.cpp
+containers\unord\unord.map\unord.map.modifiers\insert_and_emplace_allocator_requirements.pass.cpp
+containers\unord\unord.set\insert_and_emplace_allocator_requirements.pass.cpp
+
+# Not yet analyzed. Assertion failed: f16_8.out(mbs, c16, c_c16p, c_c16p, c8, c8+4, c8p) == F32_8::ok
+localization\locale.categories\category.ctype\locale.codecvt\locale.codecvt.members\utf_sanity_check.pass.cpp

--- a/tests/libcxx/usual_matrix.lst
+++ b/tests/libcxx/usual_matrix.lst
@@ -1,0 +1,7 @@
+# Copyright (c) Microsoft Corporation.
+# SPDX-License-Identifier: Apache-2.0 WITH LLVM-exception
+
+PM_CL="/nologo /Od /W4 /w14061 /w14242 /w14582 /w14583 /w14587 /w14588 /w14265 /w14749 /w14841 /w14842 /w15038 /wd4643 /sdl /WX /Zc:strictStrings /D_ENABLE_STL_INTERNAL_CHECK /bigobj /FImsvc_stdlib_force_include.h /permissive-"
+RUNALL_CROSSLIST
+PM_CL="/EHsc /MTd /D_ITERATOR_DEBUG_LEVEL=2 /std:c++latest /analyze"
+PM_COMPILER="clang-cl" PM_CL="-fno-ms-compatibility -fno-delayed-template-parsing /EHsc /MTd /std:c++latest"

--- a/tools/validate/validate.cpp
+++ b/tools/validate/validate.cpp
@@ -156,6 +156,7 @@ int main() {
         ".git"sv,
         ".vs"sv,
         ".vscode"sv,
+        "llvm-project"sv,
         "out"sv,
         "vcpkg"sv,
     };


### PR DESCRIPTION
* Port Microsoft-internal MSVC-PR-218746 and MSVC-PR-219383.
* And MSVC-PR-219451:
  * Skip llvm-project in validate.cpp.
  * Change .vscode/settings.json to CRLF.

# Description



# Checklist

Be sure you've read README.md and understand the scope of this repo.

If you're unsure about a box, leave it unchecked. A maintainer will help you.

- [ ] Identifiers in product code changes are properly `_Ugly` as per
  https://eel.is/c++draft/lex.name#3.1 or there are no product code changes.
- [ ] The STL builds successfully and all tests have passed (must be manually
  verified by an STL maintainer before automated testing is enabled on GitHub,
  leave this unchecked for initial submission).
- [ ] These changes introduce no known ABI breaks (adding members, renaming
  members, adding virtual functions, changing whether a type is an aggregate
  or trivially copyable, etc.).
- [ ] These changes were written from scratch using only this repository,
  the C++ Working Draft (including any cited standards), other WG21 papers
  (excluding reference implementations outside of proposed standard wording),
  and LWG issues as reference material. If they were derived from a project
  that's already listed in NOTICE.txt, that's fine, but please mention it.
  If they were derived from any other project (including Boost and libc++,
  which are not yet listed in NOTICE.txt), you *must* mention it here,
  so we can determine whether the license is compatible and what else needs
  to be done.
